### PR TITLE
Add coverage for utility modules

### DIFF
--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -1,0 +1,20 @@
+use RustyRunways::commands::{parse_command, Command};
+
+#[test]
+fn parse_show_airports() {
+    let cmd = parse_command("SHOW AIRPORTS").unwrap();
+    assert!(matches!(cmd, Command::ShowAirports { with_orders: false }));
+}
+
+#[test]
+fn parse_load_orders_with_brackets() {
+    let cmd = parse_command("LOAD ORDERS [1,2,3] ON 4").unwrap();
+    assert!(matches!(cmd, Command::LoadOrders { orders, plane } if orders == vec![1,2,3] && plane == 4));
+}
+
+#[test]
+fn parse_invalid_command() {
+    let err = parse_command("DO SOMETHING");
+    assert!(err.is_err());
+}
+

--- a/tests/coordinate_tests.rs
+++ b/tests/coordinate_tests.rs
@@ -1,0 +1,17 @@
+use RustyRunways::utils::coordinate::Coordinate;
+
+#[test]
+fn coordinate_creation() {
+    let c = Coordinate::new(1.0, -2.5);
+    assert_eq!(c.x, 1.0);
+    assert_eq!(c.y, -2.5);
+}
+
+#[test]
+fn coordinate_update_changes_position() {
+    let mut c = Coordinate::new(0.0, 0.0);
+    c.update(3.0, -4.0);
+    assert_eq!(c.x, 3.0);
+    assert_eq!(c.y, -4.0);
+}
+

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -1,0 +1,23 @@
+use RustyRunways::utils::errors::GameError;
+
+#[test]
+fn unknown_model_suggests_closest_name() {
+    let err = GameError::UnknownModel { input: "SparowLight".to_string(), suggestion: None };
+    let msg = format!("{}", err);
+    assert!(msg.contains("SparrowLight"));
+}
+
+#[test]
+fn unknown_model_without_suggestion() {
+    let err = GameError::UnknownModel { input: "X".to_string(), suggestion: None };
+    let msg = format!("{}", err);
+    assert!(msg.contains("`X` doesn't exist."));
+}
+
+#[test]
+fn insufficient_funds_display() {
+    let err = GameError::InsufficientFunds { have: 100.0, need: 150.0 };
+    let msg = format!("{}", err);
+    assert_eq!(msg, "Insufficient funds. Need: $150.00. Currently have: $100.00");
+}
+

--- a/tests/events_tests.rs
+++ b/tests/events_tests.rs
@@ -1,0 +1,18 @@
+use std::collections::BinaryHeap;
+use RustyRunways::events::{Event, ScheduledEvent};
+
+#[test]
+fn scheduled_events_ordered_by_time() {
+    let mut heap = BinaryHeap::new();
+    heap.push(ScheduledEvent { time: 10, event: Event::Restock });
+    heap.push(ScheduledEvent { time: 5, event: Event::Restock });
+    assert_eq!(heap.pop().unwrap().time, 5);
+}
+
+#[test]
+fn scheduled_events_equality_ignores_payload() {
+    let a = ScheduledEvent { time: 3, event: Event::Restock };
+    let b = ScheduledEvent { time: 3, event: Event::LoadingEvent { plane: 1 } };
+    assert_eq!(a, b);
+}
+

--- a/tests/player_tests.rs
+++ b/tests/player_tests.rs
@@ -70,3 +70,29 @@ fn buy_plane_runway_too_short() {
     let result = player.buy_plane(&"SparrowLight".to_string(), &mut airport, &coord);
     assert!(matches!(result, Err(GameError::RunwayTooShort { .. })));
 }
+
+#[test]
+fn record_delivery_increments_counter() {
+    let map = Map::generate_from_seed(5, Some(2));
+    let mut player = Player::new(1_000_000.0, &map);
+    assert_eq!(player.orders_delivered, 0);
+    player.record_delivery();
+    player.record_delivery();
+    assert_eq!(player.orders_delivered, 2);
+}
+
+#[test]
+fn buy_plane_deducts_cash() {
+    use RustyRunways::utils::airplanes::models::AirplaneModel;
+    let map = Map::generate_from_seed(6, Some(2));
+    let mut player = Player::new(1_000_000.0, &map);
+    let mut airport = Airport::generate_random(6, 10);
+    airport.runway_length = 4000.0;
+    let coord = Coordinate::new(0.0, 0.0);
+    let price = AirplaneModel::SparrowLight.specs().purchase_price;
+    player
+        .buy_plane(&"SparrowLight".to_string(), &mut airport, &coord)
+        .unwrap();
+    assert!((player.cash - (1_000_000.0 - price)).abs() < f32::EPSILON);
+}
+


### PR DESCRIPTION
## Summary
- add tests for coordinates and event scheduling
- test error messaging and command parsing
- expand player tests for deliveries and cash deduction

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688cd84cd9108320833482639e01202e