### PR TITLE
Allow configuring seed, airport count, and cash from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,14 +6,65 @@ version = 4
 name = "RustyRunways"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "pyo3",
  "rand",
  "rustyline",
  "serde",
  "serde_json",
- "strsim",
+ "strsim 0.10.0",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -41,6 +92,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +139,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "endian-type"
@@ -115,6 +212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +282,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "portable-atomic"
@@ -399,6 +508,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ strsim = "0.10"
 serde_json = "1.0"
 pyo3 = "0.25.1"
 rustyline = "16.0.0"
+clap = { version = "4.5", features = ["derive"] }
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ RustyRunways is a small logistics simulation game written in Rust. You manage an
    cargo test
    ```
 
+4. **Run**
+
+   By default the game starts with a random seed and number of airports while giving the player $1,000,000 in cash:
+
+   ```bash
+   cargo run
+   ```
+
+   You can specify the configuration explicitly:
+
+   ```bash
+   cargo run -- --seed 1 --n 5 --c 1000000
+   ```
+
+   The `--seed` and `--n` options must be provided together. The starting cash `--c` option is optional and defaults to `1000000`.
+
 ---
 
 ## Commands

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use rand::Rng;
+
+use crate::game::Game;
+
+/// Command line arguments for configuring the game.
+#[derive(Parser, Debug)]
+pub struct Cli {
+    /// Seed used for deterministic world generation
+    #[arg(long)]
+    pub seed: Option<u64>,
+    /// Number of airports in the generated world
+    #[arg(long)]
+    pub n: Option<usize>,
+    /// Starting cash for the player
+    #[arg(long, default_value_t = 1_000_000.0)]
+    pub c: f32,
+}
+
+/// Initialize a [`Game`] from command line arguments.
+///
+/// * If both `seed` and `n` are provided, they are used verbatim.
+/// * If neither are provided, random values are generated.
+/// * Supplying only one of `seed` or `n` results in an error.
+pub fn init_game_from_cli(cli: Cli) -> Result<Game, String> {
+    match (cli.seed, cli.n) {
+        (Some(seed), Some(n)) => Ok(Game::new(seed, Some(n), cli.c)),
+        (None, None) => {
+            let seed = rand::thread_rng().r#gen();
+            Ok(Game::new(seed, None, cli.c))
+        }
+        _ => Err("Both --seed and --n must be specified".to_string()),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod game;
 pub mod player;
 pub mod statistics;
 pub mod utils;
+pub mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,20 @@
 use RustyRunways::commands::Command;
 use RustyRunways::utils::read::{LineReaderHelper, print_banner};
-use RustyRunways::{commands::parse_command, game::Game};
+use RustyRunways::{commands::parse_command, cli::{Cli, init_game_from_cli}};
+use clap::Parser;
 use rustyline::{ColorMode, CompletionType, Config, Editor};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     print_banner();
-    let mut game = Game::new(1, Some(5), 1_000_000.0);
+    let cli = Cli::parse();
+    let mut game = match init_game_from_cli(cli) {
+        Ok(game) => game,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    };
 
     // line parser
     let config = Config::builder()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,35 @@
+use RustyRunways::cli::{Cli, init_game_from_cli};
+use clap::Parser;
+
+#[test]
+fn cli_requires_seed_and_n() {
+    let cli = Cli::try_parse_from(["test", "--seed", "1"]).unwrap();
+    assert!(init_game_from_cli(cli).is_err());
+}
+
+#[test]
+fn cli_defaults_cash() {
+    let cli = Cli::try_parse_from(["test", "--seed", "1", "--n", "5"]).unwrap();
+    let game = init_game_from_cli(cli).unwrap();
+    assert_eq!(game.map.seed, 1);
+    assert_eq!(game.map.num_airports, 5);
+    assert_eq!(game.player.cash, 1_000_000.0);
+}
+
+#[test]
+fn cli_accepts_custom_cash() {
+    let cli =
+        Cli::try_parse_from(["test", "--seed", "2", "--n", "6", "--c", "2000000"]).unwrap();
+    let game = init_game_from_cli(cli).unwrap();
+    assert_eq!(game.map.seed, 2);
+    assert_eq!(game.map.num_airports, 6);
+    assert_eq!(game.player.cash, 2_000_000.0);
+}
+
+#[test]
+fn cli_random_when_no_args() {
+    let cli = Cli::try_parse_from(["test"]).unwrap();
+    let game = init_game_from_cli(cli).unwrap();
+    assert!(game.map.num_airports >= 4 && game.map.num_airports <= 10);
+    assert_eq!(game.player.cash, 1_000_000.0);
+}


### PR DESCRIPTION
## Summary
- add `Cli` parser to configure game seed, airport count, and starting cash
- default to random seed and airports when no args are provided
- document new command line options in README
- test CLI game initialization

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688dddb637408320942ab99fcb1710c5