### PR TITLE
Refactor plane lookup in core game logic

### DIFF
--- a/crates/core/tests/game_error_tests.rs
+++ b/crates/core/tests/game_error_tests.rs
@@ -1,0 +1,9 @@
+use rusty_runways_core::Game;
+use rusty_runways_core::utils::errors::GameError;
+
+#[test]
+fn depart_plane_invalid_id() {
+    let mut game = Game::new(0, Some(1), 1_000.0);
+    let err = game.depart_plane(99, 0).unwrap_err();
+    assert!(matches!(err, GameError::PlaneIdInvalid { id: 99 }));
+}


### PR DESCRIPTION
## Summary
- consolidate repeated plane/airport lookup logic into `plane_and_airport_idx`
- document errors for loading, unloading, departing, and refueling APIs
- add regression test for invalid plane departures

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68905716b7c48320abb87f5c780b3147