### PR TITLE
Expand tests and document Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ RustyRunways is a small logistics simulation game written in Rust. You manage an
 
 ## Project Structure
 
-The repository is organised as a Cargo workspace with two main crates:
+The repository is organised as a Cargo workspace with multiple crates:
 
 * **`rusty_runways_core`** – a library crate that implements the game engine. It contains all simulation logic and can be used without any I/O.
-* **`rusty_runways_cli`** – a binary crate that provides the command‑line interface. It depends on the core crate and offers the interactive gameplay loop.
+* **`rusty_runways_cli`** – a binary crate that provides the command‑line interface.
+* **`rusty_runways_gui`** – a graphical interface built on top of the core crate.
+* **`rusty_runways_py`** – Python bindings exposing the game for scripting or machine learning. Both single (`GameEnv`) and vectorised (`VectorGameEnv`) environments are available.
 
 Building or testing from the workspace root acts on both crates. Individual crates can also be built or tested separately using the `-p` flag.
 
@@ -91,6 +93,31 @@ Building or testing from the workspace root acts on both crates. Individual crat
    This will launch you into the main menu and allow you to create a game or initialize a random game.
 
    Please mind that the GUI is still in progress...
+
+6. **Run the Python API**
+
+   The project also exposes Python bindings that mirror the Rust game engine and support both single and vectorised environments. To install the module locally and try it out:
+
+   ```bash
+   cd crates/py
+   maturin develop --release
+   ```
+
+   Example usage from Python:
+
+   ```python
+   from rusty_runways_py import GameEnv, VectorGameEnv
+
+   g = GameEnv(seed=1)
+   g.step(1)
+   print(g.time(), g.cash())
+
+   env = VectorGameEnv(4, seed=1)
+   env.step_all(1, parallel=True)
+   print(env.times())
+   ```
+
+   Deterministic behaviour is controlled by seeds. `VectorGameEnv` can step environments in parallel using Rayon under the hood.
 
 ---
 

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -4,6 +4,15 @@ use rusty_runways_cli::cli::{Cli, init_game_from_cli};
 #[test]
 fn cli_requires_seed_and_n() {
     let cli = Cli::try_parse_from(["test", "--seed", "1"]).unwrap();
+    assert_eq!(
+        init_game_from_cli(cli).unwrap_err(),
+        "Both --seed and --n must be specified"
+    );
+}
+
+#[test]
+fn cli_requires_n_and_seed() {
+    let cli = Cli::try_parse_from(["test", "--n", "5"]).unwrap();
     assert!(init_game_from_cli(cli).is_err());
 }
 
@@ -31,4 +40,23 @@ fn cli_random_when_no_args() {
     let game = init_game_from_cli(cli).unwrap();
     assert!(game.map.num_airports >= 4 && game.map.num_airports <= 10);
     assert_eq!(game.player.cash, 1_000_000.0);
+}
+
+#[test]
+fn cli_rejects_non_numeric_seed() {
+    let res = Cli::try_parse_from(["test", "--seed", "abc", "--n", "5"]);
+    assert!(res.is_err());
+}
+
+#[test]
+fn cli_rejects_non_numeric_n() {
+    let res = Cli::try_parse_from(["test", "--seed", "1", "--n", "foo"]);
+    assert!(res.is_err());
+}
+
+#[test]
+fn cli_allows_negative_cash() {
+    let cli = Cli::try_parse_from(["test", "--seed", "1", "--n", "5", "--c=-500"]).unwrap();
+    let game = init_game_from_cli(cli).unwrap();
+    assert_eq!(game.player.cash, -500.0);
 }

--- a/crates/cli/tests/command_tests.rs
+++ b/crates/cli/tests/command_tests.rs
@@ -7,8 +7,22 @@ fn parse_show_airports() {
 }
 
 #[test]
+fn parse_show_airports_with_orders() {
+    let cmd = parse_command("SHOW AIRPORTS WITH ORDERS").unwrap();
+    assert!(matches!(cmd, Command::ShowAirports { with_orders: true }));
+}
+
+#[test]
 fn parse_load_orders_with_brackets() {
     let cmd = parse_command("LOAD ORDERS [1,2,3] ON 4").unwrap();
+    assert!(
+        matches!(cmd, Command::LoadOrders { orders, plane } if orders == vec![1,2,3] && plane == 4)
+    );
+}
+
+#[test]
+fn parse_load_orders_without_brackets() {
+    let cmd = parse_command("LOAD ORDERS 1,2,3 ON 4").unwrap();
     assert!(
         matches!(cmd, Command::LoadOrders { orders, plane } if orders == vec![1,2,3] && plane == 4)
     );
@@ -24,4 +38,39 @@ fn parse_invalid_command() {
 fn parse_maintenance_command() {
     let cmd = parse_command("MAINTENANCE 3").unwrap();
     assert!(matches!(cmd, Command::Maintenance { plane_id: 3 }));
+}
+
+#[test]
+fn parse_unload_all_command() {
+    let cmd = parse_command("UNLOAD ALL FROM 2").unwrap();
+    assert!(matches!(cmd, Command::UnloadAll { plane } if plane == 2));
+}
+
+#[test]
+fn parse_empty_advances_one_hour() {
+    let cmd = parse_command("").unwrap();
+    assert!(matches!(cmd, Command::Advance { hours: 1 }));
+}
+
+#[test]
+fn parse_show_airport_with_orders() {
+    let cmd = parse_command("SHOW AIRPORTS 3 WITH ORDERS").unwrap();
+    assert!(matches!(cmd, Command::ShowAirport { id: 3, with_orders: true }));
+}
+
+#[test]
+fn parse_buy_plane_command() {
+    let cmd = parse_command("BUY PLANE CESSNA 2").unwrap();
+    assert!(matches!(cmd, Command::BuyPlane { model, airport } if model == "CESSNA" && airport == 2));
+}
+
+#[test]
+fn parse_depart_plane_command() {
+    let cmd = parse_command("DEPART PLANE 4 1").unwrap();
+    assert!(matches!(cmd, Command::DepartPlane { plane, dest } if plane == 4 && dest == 1));
+}
+
+#[test]
+fn parse_load_orders_missing_on_errors() {
+    assert!(parse_command("LOAD ORDERS 1,2 3").is_err());
 }

--- a/crates/core/tests/game_tests.rs
+++ b/crates/core/tests/game_tests.rs
@@ -1,0 +1,69 @@
+use rusty_runways_core::{
+    events::{Event, ScheduledEvent},
+    utils::airplanes::models::AirplaneStatus,
+    Game,
+};
+
+#[test]
+fn advance_zero_hours_keeps_time_and_events() {
+    let mut game = Game::new(1, Some(4), 1_000_000.0);
+    let before_time = game.time;
+    let before_len = game.events.len();
+    game.advance(0);
+    assert_eq!(game.time, before_time);
+    assert_eq!(game.events.len(), before_len);
+}
+
+#[test]
+fn tick_event_returns_false_when_empty() {
+    let mut game = Game::new(1, Some(3), 1_000_000.0);
+    game.events.clear();
+    assert!(!game.tick_event());
+}
+
+#[test]
+fn initial_events_are_scheduled() {
+    let game = Game::new(1, Some(3), 1_000_000.0);
+    let mut has_restock = false;
+    let mut has_daily = false;
+    let mut has_dynamic = false;
+    let mut has_world = false;
+    let mut has_maint = false;
+    for scheduled in game.events.clone().into_sorted_vec() {
+        match scheduled.event {
+            Event::Restock => has_restock = true,
+            Event::DailyStats => has_daily = true,
+            Event::DynamicPricing => has_dynamic = true,
+            Event::WorldEvent { .. } => has_world = true,
+            Event::MaintenanceCheck => has_maint = true,
+            _ => {}
+        }
+    }
+    assert!(has_restock && has_daily && has_dynamic && has_world && has_maint);
+}
+
+#[test]
+fn advance_runs_events_up_to_target() {
+    let mut game = Game::new(1, Some(3), 1_000_000.0);
+    game.events.clear();
+    game.airplanes[0].status = AirplaneStatus::Loading;
+    game.events.push(ScheduledEvent { time: 1, event: Event::LoadingEvent { plane: 0 } });
+    game.events.push(ScheduledEvent { time: 5, event: Event::LoadingEvent { plane: 0 } });
+    game.advance(2);
+    assert_eq!(game.time, 2);
+    assert!(matches!(game.airplanes[0].status, AirplaneStatus::Parked));
+    assert_eq!(game.events.peek().unwrap().time, 5);
+}
+
+#[test]
+fn advance_executes_event_at_target_time() {
+    let mut game = Game::new(1, Some(3), 1_000_000.0);
+    game.events.clear();
+    game.airplanes[0].status = AirplaneStatus::Loading;
+    game.events.push(ScheduledEvent { time: 4, event: Event::LoadingEvent { plane: 0 } });
+    game.advance(4);
+    assert_eq!(game.time, 4);
+    assert!(matches!(game.airplanes[0].status, AirplaneStatus::Parked));
+    assert!(game.events.is_empty());
+}
+

--- a/crates/gui/src/gui.rs
+++ b/crates/gui/src/gui.rs
@@ -934,6 +934,8 @@ mod tests {
         gui.handle_click_item(ClickItem::Airport(2));
         assert_eq!(gui.selected_airport, Some(2));
         assert!(gui.airport_panel);
+        assert!(gui.selected_airplane.is_none());
+        assert!(!gui.plane_panel);
     }
 
     #[test]
@@ -942,6 +944,8 @@ mod tests {
         gui.handle_click_item(ClickItem::Plane(7));
         assert_eq!(gui.selected_airplane, Some(7));
         assert!(gui.plane_panel);
+        assert!(gui.selected_airport.is_none());
+        assert!(!gui.airport_panel);
     }
 
     #[test]
@@ -949,5 +953,13 @@ mod tests {
         let gui = RustyRunwaysGui::default();
         assert!(matches!(gui.screen, Screen::MainMenu));
         assert!(gui.game.is_none());
+    }
+
+    #[test]
+    fn default_inputs_are_seeded() {
+        let gui = RustyRunwaysGui::default();
+        assert_eq!(gui.seed_str, "1");
+        assert_eq!(gui.airports_str, "5");
+        assert_eq!(gui.cash_str, "1000000");
     }
 }

--- a/crates/py/tests/test_py_api.py
+++ b/crates/py/tests/test_py_api.py
@@ -77,3 +77,51 @@ def test_determinism():
     env2.step_all(1, parallel=True)
     assert env1.state_all_json() == env2.state_all_json()
 
+
+def test_reset_resets_state():
+    g = GameEnv(seed=1, num_airports=3, cash=500.0)
+    g.step(5)
+    g.reset(seed=2, num_airports=4, cash=600.0)
+    assert g.time() == 0
+    assert g.cash() == 600.0
+    assert g.seed() == 2
+
+
+def test_vector_env_parallel_vs_serial():
+    parallel = VectorGameEnv(2, seed=1)
+    serial = VectorGameEnv(2, seed=1)
+    parallel.step_all(3, parallel=True)
+    serial.step_all(3, parallel=False)
+    assert parallel.times() == serial.times() == [3, 3]
+    assert parallel.cashes() == serial.cashes()
+
+
+def test_vector_env_reset_all_mismatch():
+    env = VectorGameEnv(2, seed=1)
+    import pytest
+    with pytest.raises(ValueError):
+        env.reset_all(seed=[1, 2, 3])
+
+
+def test_vector_env_step_masked_length_error():
+    env = VectorGameEnv(2, seed=1)
+    import pytest
+    with pytest.raises(ValueError):
+        env.step_masked(1, [True])
+
+
+def test_vector_env_execute_all_none():
+    env = VectorGameEnv(2, seed=1)
+    res = env.execute_all([None, "ADVANCE 1"], parallel=False)
+    assert res[0] == (True, None)
+    assert res[1][0] is True and res[1][1] is None
+    assert env.times() == [0, 1]
+
+
+def test_vector_env_reset_at_only_one():
+    env = VectorGameEnv(2, seed=1)
+    env.step_all(2, parallel=False)
+    env.reset_at(0, seed=5, num_airports=3, cash=700.0)
+    assert env.times() == [0, 2]
+    assert env.seeds() == [5, 2]
+


### PR DESCRIPTION
## Summary
- add game advance scheduling tests for mid-advance and boundary-time processing
- harden CLI parsing with numeric validation, negative cash handling, and targeted command coverage
- widen GUI unit tests for click handling and default input fields

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a8e8e5a48320bcb09dca7242f831