### PR TITLE
Use tarpaulin config and test error displays

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,9 @@ jobs:
         run: |
           # run all tests, produce XML for Codecov
           cargo tarpaulin \
+            --config tarpaulin.toml \
             --all-features \
             --workspace \
-            --exclude rusty_runways_py \
             --timeout 120 \
             --out Xml \
             --output-dir coverage

--- a/crates/core/tests/errors_tests.rs
+++ b/crates/core/tests/errors_tests.rs
@@ -1,4 +1,6 @@
-use rusty_runways_core::utils::errors::GameError;
+use rusty_runways_core::utils::{
+    airplanes::models::AirplaneStatus, coordinate::Coordinate, errors::GameError,
+};
 
 #[test]
 fn unknown_model_suggests_closest_name() {
@@ -31,4 +33,71 @@ fn insufficient_funds_display() {
         msg,
         "Insufficient funds. Need: $150.00. Currently have: $100.00"
     );
+}
+
+#[test]
+fn other_error_displays() {
+    let cases = vec![
+        (
+            GameError::OutOfRange {
+                distance: 1.0,
+                range: 0.5,
+            },
+            "outside of the airplane range",
+        ),
+        (
+            GameError::RunwayTooShort {
+                required: 10.0,
+                available: 5.0,
+            },
+            "requires at least",
+        ),
+        (
+            GameError::MaxPayloadReached {
+                current_capacity: 1.0,
+                maximum_capacity: 2.0,
+                added_weight: 3.0,
+            },
+            "Cannot load order",
+        ),
+        (GameError::OrderIdInvalid { id: 1 }, "Order with id 1"),
+        (GameError::PlaneIdInvalid { id: 2 }, "Plan with id 2"),
+        (GameError::AirportIdInvalid { id: 3 }, "Airport with id 3"),
+        (
+            GameError::AirportLocationInvalid {
+                location: Coordinate { x: 1.0, y: 2.0 },
+            },
+            "No airport found",
+        ),
+        (
+            GameError::PlaneNotAtAirport { plane_id: 4 },
+            "Plane 4 is not located",
+        ),
+        (
+            GameError::PlaneNotReady {
+                plane_state: AirplaneStatus::Parked,
+            },
+            "Airplane not ready",
+        ),
+        (
+            GameError::InsufficientFuel {
+                have: 1.0,
+                need: 2.0,
+            },
+            "Insufficient fuel",
+        ),
+        (GameError::NoCargo, "No cargo to unload"),
+        (GameError::SameAirport, "Cannot fly to the airport"),
+        (
+            GameError::InvalidCommand {
+                msg: "oops".to_string(),
+            },
+            "oops",
+        ),
+    ];
+
+    for (err, expected) in cases {
+        let msg = format!("{}", err);
+        assert!(msg.contains(expected));
+    }
 }

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,8 @@
+[test_config]
+manifest-path = "./Cargo.toml"
+exclude = ["rusty_runways_py"]
+exclude-files = [
+    "crates/gui/**",
+    "crates/py/**",
+    "crates/cli/src/main.rs"
+]


### PR DESCRIPTION
## Summary
- configure tarpaulin to skip GUI, Python, and CLI entrypoint files
- add comprehensive display tests for `GameError` variants
- point CI coverage job at shared config without redundant crate exclusion

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rusty_runways_core`
- `cargo tarpaulin --workspace --out Xml --skip-clean`


------
https://chatgpt.com/codex/tasks/task_e_68a5f61fc4288320b663cbcfbba24548